### PR TITLE
Add Dockerfile and docs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.10-slim
+
+WORKDIR /app
+
+COPY . /app
+
+RUN pip install --no-cache-dir mcp[cli] docx2pdf pdf2docx pillow pandas pdfkit markdown
+
+EXPOSE 3333
+
+CMD ["python", "file_converter_server.py"]

--- a/README.md
+++ b/README.md
@@ -80,6 +80,15 @@ Optionally, you can install the server on Claude Desktop with:
 mcp install file_converter_server.py --name "File Converter"
 ```
 
+### Running with Docker
+
+You can also build and run the server using Docker:
+
+```bash
+docker build -t file-converter .
+docker run -p 3333:3333 file-converter
+```
+
 ### API / Tools
 
 The MCP server exposes the following tools:

--- a/README_CN.md
+++ b/README_CN.md
@@ -77,6 +77,15 @@ mcp dev file_converter_server.py
 mcp install file_converter_server.py --name "File Converter"
 ```
 
+### 使用 Docker 运行
+
+你也可以通过 Docker 构建并运行服务器：
+
+```bash
+docker build -t file-converter .
+docker run -p 3333:3333 file-converter
+```
+
 ### API / 工具
 
 该 MCP 服务器暴露以下工具：


### PR DESCRIPTION
## Summary
- add `Dockerfile` for running server with Docker
- document Docker usage in README and README_CN

## Testing
- `flake8 .`

------
https://chatgpt.com/codex/tasks/task_e_6856303017088327ab8187090de5ee3b