### PR TITLE
修复缺少MCP依赖时的错误提示

### DIFF
--- a/file_converter_server.py
+++ b/file_converter_server.py
@@ -11,7 +11,12 @@ It supports various file format conversions such as:
 The server is built using the Model Context Protocol (MCP) Python SDK.
 """
 
-from mcp.server.fastmcp import FastMCP, Context
+try:
+    from mcp.server.fastmcp import FastMCP, Context
+except ImportError as e:
+    raise ImportError(
+        "MCP 库未安装，请运行 `pip install mcp[cli]` 安装依赖后再试。"
+    ) from e
 import os
 import base64
 from pathlib import Path


### PR DESCRIPTION
## Summary
- 在 `file_converter_server.py` 中新增导入失败处理
- 若未安装 `mcp` 库，给出中文提示信息

## Testing
- `python -m py_compile file_converter_server.py`
- 手动运行 `python file_converter_server.py` 并终止

------
https://chatgpt.com/codex/tasks/task_e_6856316e4a5c8327869d9e91914e1d96